### PR TITLE
[bug] 화면 이동시 ViewModel 유지

### DIFF
--- a/app/src/main/java/com/meezzi/deepmedi/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/meezzi/deepmedi/presentation/navigation/AppNavGraph.kt
@@ -1,16 +1,21 @@
 package com.meezzi.deepmedi.presentation.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.meezzi.deepmedi.presentation.ui.camera.CameraScreen
+import com.meezzi.deepmedi.presentation.ui.camera.UploadViewModel
 import com.meezzi.deepmedi.presentation.ui.permission.PermissionScreen
 import com.meezzi.deepmedi.presentation.ui.result.ResultScreen
 
 @Composable
 fun AppNavGraph(navController: NavHostController = rememberNavController()) {
+
+    val uploadViewModel: UploadViewModel = hiltViewModel()
+
     NavHost(
         navController = navController,
         startDestination = Screen.Permission.route
@@ -32,11 +37,14 @@ fun AppNavGraph(navController: NavHostController = rememberNavController()) {
                 onNavigateToResult = {
                     navController.navigate(Screen.Result.route)
                 },
+                uploadViewModel = uploadViewModel,
             )
         }
 
         composable(Screen.Result.route) {
-            ResultScreen()
+            ResultScreen(
+                uploadViewModel = uploadViewModel,
+            )
         }
     }
 }


### PR DESCRIPTION
### 🚨 문제 상황
사진 촬영 후, 응답받은 데이터가 결과 화면에 표시가 안되는 상황이 발생했다.

정상적으로 응답 데이터는 받았지만 UI가 업데이트가 안되는 상황이다.

<br>

### 💡 기대 동작
사진 촬영 후, 응답받은 데이터가 결과 화면에 표시된다.

<br>

### 💫 오류 원인
카메라 화면과 결과 화면은 모두 UploadViewModel에 의존하고 있다.

하지만, 카메라 화면에서 결과 화면으로 이동할 때,
기존 ViewModel을 재사용하지 않고 새로 ViewModel 인스턴스를 생성하면서 데이터가 초기화되었다.

즉, 카메라 화면에서 응답받은 데이터를 결과 화면에서 공유하지 못한 것이 문제가 되었다.

<br>

### 🔧 해결 방안
NavGraph에서 ViewModel 인스턴스를 생성하여 카메라 화면과 결과 화면에서 동일한 ViewModel 인스턴스를 사용하도록 수정하였다.